### PR TITLE
Category amendment

### DIFF
--- a/app/Google/Chrome/84.0.4147.105.json
+++ b/app/Google/Chrome/84.0.4147.105.json
@@ -1,5 +1,5 @@
 {
-  "Category": "entertainment",
+  "Category": "browser",
   "Manifest": "4.3.7.9",
   "Nuspec": true,
   "NuspecURI": "https://raw.githubusercontent.com/chocolatey-community/chocolatey-coreteampackages/master/automatic/googlechrome/googlechrome.nuspec",

--- a/app/Google/Chrome/latest.json
+++ b/app/Google/Chrome/latest.json
@@ -1,5 +1,5 @@
 {
-  "Category": "entertainment",
+  "Category": "browser",
   "Manifest": "4.3.7.9",
   "Nuspec": true,
   "NuspecURI": "https://raw.githubusercontent.com/chocolatey-community/chocolatey-coreteampackages/master/automatic/googlechrome/googlechrome.nuspec",


### PR DESCRIPTION
Google Chrome was listed as `entertainment` instead of `browser` like it should have been.